### PR TITLE
add use strict to plant.js

### DIFF
--- a/Plant.js
+++ b/Plant.js
@@ -1,4 +1,4 @@
-
+"use strict";
 let rp         = require('./request_promise')
 let cheerio    = require('cheerio')
 


### PR DESCRIPTION
I added "use strict";

The es6 features aren't supported without it as running an app that uses plant.js gives this error for me:

```
Plant.js:2
let rp         = require('./request_promise')
^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

```